### PR TITLE
Ensure gradlew is executable

### DIFF
--- a/build-script.sh
+++ b/build-script.sh
@@ -31,8 +31,8 @@ fi
 
 cd project-folder
 
-if [ ! -e "gradlew" ]; then
-    echo "Pulled repo did not have internal gradle wrapper. Please specify repo with one, or use different building container"
+if [ ! -x "gradlew" ]; then
+    echo "Pulled repo did not have an executable internal gradle wrapper. Check permissions, specify a repo with one, or use different building container"
     exit
 fi
 


### PR DESCRIPTION
The original code can get to a state where it tries to run `gradlew` when it doesn't have permission to.

This can be fixed by either granting permission (`chmod`) at runtime checking for the executable bit.  I've opted for the latter -- `gradlew` will need to be executable to work on Linux or macOS, and repo owners should probably be running builds and tests using gradle locally before pushing anyway.