### PR TITLE
Prevent gradle daemon from being used

### DIFF
--- a/build-script.sh
+++ b/build-script.sh
@@ -36,7 +36,7 @@ if [ ! -e "gradlew" ]; then
     exit
 fi
 
+export GRADLE_OPTS='-Dorg.gradle.daemon=false'
 ./gradlew clean build publish
-./gradlew --stop # needed to kill the container, else daemon will keep it alive
 
 echo "Build finished"


### PR DESCRIPTION
There are a few ways to prevent the daemon from ever running:
https://docs.gradle.org/current/userguide/gradle_daemon.html#daemon_faq

I've added an env var in case other options are ever necessary.  The `--no-daemon` switch is also straightforward and would work fine too.